### PR TITLE
Updates to ACDC vLEI samples and schema to match latest spec.

### DIFF
--- a/samples/acdc/gleif-vLEI-credential.json
+++ b/samples/acdc/gleif-vLEI-credential.json
@@ -2,13 +2,13 @@
   "v": "ACDC10JSON00011c_",
   "d": "Esmy31gPoOJzxv2JwpGBb_zJ7XkNUVYZZheMifW89CQY",
   "i": "did:keri:ELzvA4arGVUFitOpSCjWvmpfVzTmJR4wIVnsnRtlCPG",
+  "ri": "did:keri:EymRy7xMwsxUelUauaXtMxTfPAMPAI6FkekwlOjkggt",
   "s": "Ek6vA-fVXDRbraVi7a9ydKStHiByUoF37Cgz4L58LWds",
   "a": {
     "d": "ErmVM5JGLewHJrSqIuhwWktoIlfffh7sHIGAQvtcFSU",
     "i": "did:keri:Eky8a1Xo48shGZobJA2C_NGVXK59P04mY9QmWEbflHBM",
     "dt": "2021-06-09T17:35:54.169967+00:00",
-    "ri": "did:keri:EymRy7xMwsxUelUauaXtMxTfPAMPAI6FkekwlOjkggt",
     "LEI": "254900OPPU84GM83MG36"
   },
-  "p": []
+  "e": {}
 }

--- a/samples/acdc/legal-entity-engagement-context-role-vLEI-credential.json
+++ b/samples/acdc/legal-entity-engagement-context-role-vLEI-credential.json
@@ -2,25 +2,23 @@
   "v": "ACDC10JSON00011c_",
   "d": "EpcEvrX2gGTpmKbIG25GSA7_LsWwwzVQ6aUilgBubpGI",
   "i": "did:keri:EmSIYYxvgtKn9jAp8GcK3fXOwTeyBIcAnRnyrLNfKjVI",
+  "ri": "did:keri:EymRy7xMwsxUelUauaXtMxTfPAMPAI6FkekwlOjkggt",
   "s": "EZdaE1HCu2ZhyIhpXTWfGSLS2kirKexaC-4up3sIUz1I",
-  "n": "IY7-g7wTfta1087YAdUXTbuI0Vklqt8pQxTgc3Rtz0o",
+  "u": "IY7-g7wTfta1087YAdUXTbuI0Vklqt8pQxTgc3Rtz0o",
   "a": {
     "d": "EG7PfBZbyXS0huxbnvMD-jOdTnDCCaT4CO6xId-ATNWg",
     "i": "did:keri:EFs6d-7q-l6tDMn_yYFyFzaT89sSFNLCOaKqYMF-7L_0",
     "dt": "2021-06-09T17:35:54.169967+00:00",
-    "ri": "did:keri:EymRy7xMwsxUelUauaXtMxTfPAMPAI6FkekwlOjkggt",
     "LEI": "254900YH3ZCDPE1E5306",
     "personLegalName": "Anne Jones",
     "engagementContextRole": "Project Manager"
   },
-  "p": [
-    {
-      "legalEntityvLEICredential": {
-        "d": "EBDmgKOAEwnMGsofWg2m0l63J1awfJafqJyCzTnVkdSw",
-        "i": "Et2DOOu4ivLsjpv89vgv6auPntSLx4CvOhGUxMhxPS24"
-      }
+  "e": {
+    "d": "EBDmgKOAEwnMGsofWg2m0l63J1awfJafqJyCzTnVkdSw",
+    "legalEntityvLEICredential": {
+      "n": "Et2DOOu4ivLsjpv89vgv6auPntSLx4CvOhGUxMhxPS24"
     }
-  ],
+  },
   "r": [
     {
       "usageDisclaimer": "Usage of a valid Legal Entity vLEI Credential does not assert that the Legal Entity is trustworthy, honest, reputable in its business dealings, safe to do business with, or compliant with any laws."

--- a/samples/acdc/legal-entity-official-organizational-role-vLEI-credential.json
+++ b/samples/acdc/legal-entity-official-organizational-role-vLEI-credential.json
@@ -2,24 +2,22 @@
   "v": "ACDC10JSON00011c_",
   "d": "E1qH1E2zo7rnW1Pwm3NuYOXZ1SsVH3yeV2Iifj2wtCgA",
   "i": "did:keri:EZBfSGG5k1CZYk1QH3GXFPtEwLHf0H06zuDUEJRyar1E",
+  "ri": "did:keri:EymRy7xMwsxUelUauaXtMxTfPAMPAI6FkekwlOjkggt",
   "s": "EDg-Ji3kmi_G97Jctxeajpmp1-A8gSpeyElm-XCzTxiE",
   "a": {
     "d": "ErmVM5JGLewHJrSqIuhwWktoIlfffh7sHIGAQvtcFSU",
     "i": "did:keri:E70sYPRHygB9aOzgg_xEbI5RCVyRRCAXWG9uHyRNrqYE",
     "dt": "2021-06-09T17:35:54.169967+00:00",
-    "ri": "did:keri:EymRy7xMwsxUelUauaXtMxTfPAMPAI6FkekwlOjkggt",
     "LEI": "254900YH3ZCDPE1E5306",
     "personLegalName": "John Smith",
     "officialRole": "Chief Executive Officer"
   },
-  "p": [
-    {
-      "legalEntityvLEICredential": {
-        "d": "EBDmgKOAEwnMGsofWg2m0l63J1awfJafqJyCzTnVkdSw",
-        "i": "Et2DOOu4ivLsjpv89vgv6auPntSLx4CvOhGUxMhxPS24"
-      }
+  "e": {
+    "d": "EBDmgKOAEwnMGsofWg2m0l63J1awfJafqJyCzTnVkdSw",
+    "legalEntityvLEICredential": {
+      "n": "Et2DOOu4ivLsjpv89vgv6auPntSLx4CvOhGUxMhxPS24"
     }
-  ],
+  },
   "r": [
     {
       "usageDisclaimer": "Usage of a valid Legal Entity vLEI Credential does not assert that the Legal Entity is trustworthy, honest, reputable in its business dealings, safe to do business with, or compliant with any laws."

--- a/samples/acdc/legal-entity-vLEI-credential.json
+++ b/samples/acdc/legal-entity-vLEI-credential.json
@@ -2,22 +2,20 @@
   "v": "ACDC10JSON00011c_",
   "d": "EBdXt3gIXOf2BBWNHdSXCJnFJL5OuQPyM5K0neuniccM",
   "i": "did:keri:EmkPreYpZfFk66jpf3uFv7vklXKhzBrAqjsKAn2EDIPM",
+  "ri": "did:keri:EymRy7xMwsxUelUauaXtMxTfPAMPAI6FkekwlOjkggt",
   "s": "E46jrVPTzlSkUPqGGeIZ8a8FWS7a6s4reAXRZOkogZ2A",
   "a": {
     "d": "EgveY4-9XgOcLxUderzwLIr9Bf7V_NHwY1lkFrn9y2PY",
     "i": "did:keri:EQzFVaMasUf4cZZBKA0pUbRc9T8yUXRFLyM1JDASYqAA",
     "dt": "2021-06-09T17:35:54.169967+00:00",
-    "ri": "did:keri:EymRy7xMwsxUelUauaXtMxTfPAMPAI6FkekwlOjkggt",
     "LEI": "254900OPPU84GM83MG36"
   },
-  "p": [
-    {
-      "qualifiedvLEIIssuervLEICredential": {
-        "d": "EIl3MORH3dCdoFOLe71iheqcywJcnjtJtQIYPvAu6DZA",
-        "i": "Et2DOOu4ivLsjpv89vgv6auPntSLx4CvOhGUxMhxPS24"
-      }
+  "e": {
+    "d": "EIl3MORH3dCdoFOLe71iheqcywJcnjtJtQIYPvAu6DZA",
+    "qualifiedvLEIIssuervLEICredential": {
+      "n": "Et2DOOu4ivLsjpv89vgv6auPntSLx4CvOhGUxMhxPS24"
     }
-  ],
+  },
   "r": [
     {
       "usageDisclaimer": "Usage of a valid Legal Entity vLEI Credential does not assert that the Legal Entity is trustworthy, honest, reputable in its business dealings, safe to do business with, or compliant with any laws."

--- a/samples/acdc/qualified-vLEI-issuer-vLEI-credential.json
+++ b/samples/acdc/qualified-vLEI-issuer-vLEI-credential.json
@@ -2,13 +2,13 @@
   "v": "ACDC10JSON00011c_",
   "d": "EYo4R9I08Et5H5SWKG8ZMS83r8FmRtfahN0V9NbG9zdw",
   "i": "did:keri:Ei5csblWpTy22uVkbZrZxvSUORxPvIlrfpq2e1hKTtfA",
+  "ri": "did:keri:EymRy7xMwsxUelUauaXtMxTfPAMPAI6FkekwlOjkggt",
   "s": "ECcj1CBn4dpo6ZOmZQNtAjXxT4_MsVXipt5VTPjvSAf0",
   "a": {
     "d": "Ea4ny_YZAtAGUwGSyH7iFiKjpM3yFiDHcjrdomqt7Ryk",
     "i": "did:keri:EP2ukuiw_0xcp943NWz4IRnNtxwx7rzROwV1D_ZRP0XQ",
     "dt": "2021-06-09T17:35:54.169967+00:00",
-    "ri": "did:keri:EymRy7xMwsxUelUauaXtMxTfPAMPAI6FkekwlOjkggt",
     "LEI": "5493001KJTIIGC8Y1R12"
   },
-  "p": []
+  "e": {}
 }

--- a/schema/acdc/gleif-vLEI-credential.json
+++ b/schema/acdc/gleif-vLEI-credential.json
@@ -15,6 +15,10 @@
     "i": {
       "type": "string"
     },
+    "ri": {
+      "description": "credential status registry",
+      "type": "string"
+    },
     "s": {
       "description": "schema SAID",
       "type": "string"
@@ -33,10 +37,6 @@
           "format": "date-time",
           "type": "string"
         },
-        "ri": {
-          "description": "credential status registry",
-          "type": "string"
-        },
         "LEI": {
           "type": "string"
         }
@@ -45,20 +45,18 @@
       "required": [
         "d",
         "dt",
-        "ri",
         "LEI"
       ],
       "type": "object"
     },
-    "p": {
-      "maxItems": 0,
-      "minItems": 0,
-      "type": "array"
+    "e": {
+      "type": "object"
     }
   },
   "additionalProperties": false,
   "required": [
     "d",
-    "i"
+    "i",
+    "ri"
   ]
 }

--- a/schema/acdc/legal-entity-engagement-context-role-vLEI-credential.json
+++ b/schema/acdc/legal-entity-engagement-context-role-vLEI-credential.json
@@ -14,11 +14,15 @@
     "i": {
       "type": "string"
     },
+    "ri": {
+      "description": "credential status registry",
+      "type": "string"
+    },
     "s": {
       "description": "schema SAID",
       "type": "string"
     },
-    "n": {
+    "u": {
       "description": "one time use nonce",
       "type": "string"
     },
@@ -36,10 +40,6 @@
           "format": "date-time",
           "type": "string"
         },
-        "ri": {
-          "description": "credential status registry",
-          "type": "string"
-        },
         "LEI": {
           "type": "string"
         },
@@ -54,43 +54,39 @@
       "required": [
         "i",
         "dt",
-        "ri",
         "LEI",
         "personLegalName",
         "engagementContextRole"
       ],
       "type": "object"
     },
-    "p": {
-      "contains": {
-        "type": "object"
-      },
-      "description": "source block",
-      "items": {
-        "properties": {
-          "legalEntityvLEICredential": {
-            "description": "chain to issuer credential",
-            "properties": {
-              "d": {
-                "type": "string"
-              },
-              "i": {
-                "type": "string"
-              }
-            },
-            "additionalProperties": false,
-            "type": "object"
-          }
+    "e": {
+      "description": "edges block",
+      "properties": {
+        "d": {
+          "description": "said of edges block",
+          "type": "string"
         },
-        "additionalProperties": false,
-        "required": [
-          "legalEntityvLEICredential"
-        ],
-        "type": "object"
+        "legalEntityvLEICredential": {
+          "description": "chain to issuer credential",
+          "properties": {
+            "n": {
+              "type": "string"
+            }
+          },
+          "additionalProperties": false,
+          "required": [
+            "n"
+          ],
+          "type": "object"
+        }
       },
-      "maxItems": 1,
-      "minItems": 1,
-      "type": "array"
+      "additionalProperties": false,
+      "required": [
+        "d",
+        "legalEntityvLEICredential"
+      ],
+      "type": "object"
     },
     "r": {
       "contains": {
@@ -104,10 +100,12 @@
   "required": [
     "v",
     "i",
+    "ri",
     "s",
     "d",
     "r",
-    "a"
+    "a",
+    "e"
   ],
   "type": "object"
 }

--- a/schema/acdc/legal-entity-official-organizational-role-vLEI-credential.json
+++ b/schema/acdc/legal-entity-official-organizational-role-vLEI-credential.json
@@ -14,6 +14,10 @@
     "i": {
       "type": "string"
     },
+    "ri": {
+      "description": "credential status registry",
+      "type": "string"
+    },
     "s": {
       "description": "schema SAID",
       "type": "string"
@@ -32,10 +36,6 @@
           "format": "date-time",
           "type": "string"
         },
-        "ri": {
-          "description": "credential status registry",
-          "type": "string"
-        },
         "LEI": {
           "type": "string"
         },
@@ -50,43 +50,39 @@
       "required": [
         "i",
         "dt",
-        "ri",
         "LEI",
         "personLegalName",
         "officialRole"
       ],
       "type": "object"
     },
-    "p": {
-      "contains": {
-        "type": "object"
-      },
-      "description": "source block",
-      "items": {
-        "properties": {
-          "legalEntityvLEICredential": {
-            "description": "chain to issuer credential",
-            "properties": {
-              "d": {
-                "type": "string"
-              },
-              "i": {
-                "type": "string"
-              }
-            },
-            "additionalProperties": false,
-            "type": "object"
-          }
+    "e": {
+      "description": "edges block",
+      "properties": {
+        "d": {
+          "description": "said of edges block",
+          "type": "string"
         },
-        "additionalProperties": false,
-        "required": [
-          "legalEntityvLEICredential"
-        ],
-        "type": "object"
+        "legalEntityvLEICredential": {
+          "description": "chain to issuer credential",
+          "properties": {
+            "n": {
+              "type": "string"
+            }
+          },
+          "additionalProperties": false,
+          "required": [
+            "n"
+          ],
+          "type": "object"
+        }
       },
-      "maxItems": 1,
-      "minItems": 1,
-      "type": "array"
+      "additionalProperties": false,
+      "required": [
+        "d",
+        "legalEntityvLEICredential"
+      ],
+      "type": "object"
     },
     "r": {
       "contains": {
@@ -99,8 +95,10 @@
   "additionalProperties": false,
   "required": [
     "i",
+    "ri",
     "s",
     "d",
+    "e",
     "r"
   ],
   "type": "object"

--- a/schema/acdc/legal-entity-vLEI-credential.json
+++ b/schema/acdc/legal-entity-vLEI-credential.json
@@ -14,6 +14,10 @@
     "i": {
       "type": "string"
     },
+    "ri": {
+      "description": "credential status registry",
+      "type": "string"
+    },
     "s": {
       "description": "schema SAID",
       "type": "string"
@@ -32,10 +36,6 @@
           "format": "date-time",
           "type": "string"
         },
-        "ri": {
-          "description": "credential status registry",
-          "type": "string"
-        },
         "LEI": {
           "type": "string"
         }
@@ -44,41 +44,37 @@
       "required": [
         "i",
         "dt",
-        "ri",
         "LEI"
       ],
       "type": "object"
     },
-    "p": {
-      "contains": {
-        "type": "object"
-      },
-      "description": "source block",
-      "items": {
-        "properties": {
-          "qualifiedvLEIIssuervLEICredential": {
-            "description": "chain to issuer credential",
-            "properties": {
-              "d": {
-                "type": "string"
-              },
-              "i": {
-                "type": "string"
-              }
-            },
-            "additionalProperties": false,
-            "type": "object"
-          }
+    "e": {
+      "description": "edges block",
+      "properties": {
+        "d": {
+          "description": "SAID of edges block",
+          "type": "string"
         },
-        "additionalProperties": false,
-        "required": [
-          "qualifiedvLEIIssuervLEICredential"
-        ],
-        "type": "object"
+        "qualifiedvLEIIssuervLEICredential": {
+          "description": "node SAID of issuer credential",
+          "properties": {
+            "n": {
+              "type": "string"
+            }
+          },
+          "additionalProperties": false,
+          "required": [
+            "n"
+          ],
+          "type": "object"
+        }
       },
-      "maxItems": 1,
-      "minItems": 1,
-      "type": "array"
+      "additionalProperties": false,
+      "required": [
+        "d",
+        "qualifiedvLEIIssuervLEICredential"
+      ],
+      "type": "object"
     },
     "r": {
       "contains": {
@@ -91,8 +87,10 @@
   "additionalProperties": false,
   "required": [
     "i",
+    "ri",
     "s",
     "d",
+    "e",
     "r"
   ],
   "type": "object"

--- a/schema/acdc/qualified-vLEI-issuer-vLEI-credential.json
+++ b/schema/acdc/qualified-vLEI-issuer-vLEI-credential.json
@@ -14,6 +14,10 @@
     "i": {
       "type": "string"
     },
+    "ri": {
+      "description": "credential status registry",
+      "type": "string"
+    },
     "s": {
       "description": "schema SAID",
       "type": "string"
@@ -32,10 +36,6 @@
           "format": "date-time",
           "type": "string"
         },
-        "ri": {
-          "description": "credential status registry",
-          "type": "string"
-        },
         "LEI": {
           "type": "string"
         },
@@ -48,20 +48,19 @@
       "required": [
         "i",
         "dt",
-        "ri",
         "LEI"
       ],
       "type": "object"
     },
-    "p": {
-      "maxItems": 0,
-      "minItems": 0,
-      "type": "array"
+    "e": {
+      "type": "object"
     }
   },
   "additionalProperties": false,
   "required": [
     "i",
+    "ri",
+    "s",
     "d"
   ],
   "type": "object"


### PR DESCRIPTION
Moved `ri` field, renamed `p` -> `e` and inside the new `e` block moved `d` and renamed `i` -> `n`.

Also change the nonce `n` field in the ECR to `u`.