### PR TITLE
New QVI Authorization Credential Schema

### DIFF
--- a/samples/acdc/ecr-authorization-vlei-credential.json
+++ b/samples/acdc/ecr-authorization-vlei-credential.json
@@ -1,0 +1,28 @@
+{
+  "v": "ACDC10JSON0004e4_",
+  "d": "EuF1gpodKbbqS0fqmUiOYf-MusuNvi0OmY8Js6SKSdfE",
+  "i": "EKXPX7hWw8KK5Y_Mxs2TOuCrGdN45vPIZ78NofRlVBws",
+  "ri": "EuqwB_iOD86eK0ynAhA6AYwWvPeBhvmbcmOD-9cCmiVU",
+  "s": "ELG17Q0M-uLZcjidzVbF7KBkoUhZa1ie3Az3Q_8aYi8s",
+  "a": {
+    "d": "E9-86Jag34CrJpfNFz_-7E5HA0Dj0FvcYNoFVe7qwkiI",
+    "dt": "2022-08-25T14:07:30.536257+00:00",
+    "i": "EY4ldIBDZP4Tpnm3RX320BO0yz8Uz2nUSN-C409GnCJM",
+    "AID": "Esf8b_AngI1d0KbOFjPGIfpVani0HTagWeaYTLs14PlE",
+    "LEI": "6383001AJTYIGC8Y1X37",
+    "personLegalName": "John Smith",
+    "engagementContextRole": "Chief Executive Officer"
+  },
+  "e": {
+    "d": "EsOf5_YgX_64z4YuHNFWLUnIKcyvsVQOe_vJ_638X6gE",
+    "le": {
+      "n": "ESyLzoJC4L_1abXOEN4f6uNZCmhqyEHg2geBHFhJ8KDs",
+      "s": "EWJkQCFvKuyxZi582yJPb0wcwuW3VXmFNuvbQuBpgmIs"
+    }
+  },
+  "r": {
+    "d": "EDIai3Wkd-Z_4cezz9nYEcCK3KNH5saLvZoS_84JL6NU",
+    "usageDisclaimer": "Usage of a valid Legal Entity vLEI Credential does not assert that the Legal Entity is trustworthy, honest, reputable in its business dealings, safe to do business with, or compliant with any laws.",
+    "issuanceDisclaimer": "Issuance of a valid Legal Entity vLEI Credential only establishes that the information in the requirements in the Identity Verification section 6.3 of the Credential Governance Framework were met in accordance with the vLEI Ecosystem Governance Framework."
+  }
+}

--- a/samples/acdc/legal-entity-engagement-context-role-vLEI-credential.json
+++ b/samples/acdc/legal-entity-engagement-context-role-vLEI-credential.json
@@ -16,9 +16,9 @@
   "e": {
     "d": "EBDmgKOAEwnMGsofWg2m0l63J1awfJafqJyCzTnVkdSw",
     "o": "AND",
-    "le": {
+    "auth": {
       "n": "Et2DOOu4ivLsjpv89vgv6auPntSLx4CvOhGUxMhxPS24",
-      "s": "EWJkQCFvKuyxZi582yJPb0wcwuW3VXmFNuvbQuBpgmIs",
+      "s": "ELG17Q0M-uLZcjidzVbF7KBkoUhZa1ie3Az3Q_8aYi8s",
       "o": "NI2I"
     },
     "qvi": {

--- a/samples/acdc/legal-entity-official-organizational-role-vLEI-credential.json
+++ b/samples/acdc/legal-entity-official-organizational-role-vLEI-credential.json
@@ -15,9 +15,9 @@
   "e": {
     "d": "EBDmgKOAEwnMGsofWg2m0l63J1awfJafqJyCzTnVkdSw",
     "o": "AND",
-    "le": {
+    "auth": {
       "n": "Et2DOOu4ivLsjpv89vgv6auPntSLx4CvOhGUxMhxPS24",
-      "s": "EWJkQCFvKuyxZi582yJPb0wcwuW3VXmFNuvbQuBpgmIs",
+      "s": "EDpuiVPt4_sa1pShx6vOCnseru1edVPeNvRaQm6HrmMI",
       "o": "NI2I"
     },
     "qvi": {

--- a/samples/acdc/oor-authorization-vlei-credential.json
+++ b/samples/acdc/oor-authorization-vlei-credential.json
@@ -1,0 +1,28 @@
+{
+  "v": "ACDC10JSON0004e4_",
+  "d": "EuF1gpodKbbqS0fqmUiOYf-MusuNvi0OmY8Js6SKSdfE",
+  "i": "EKXPX7hWw8KK5Y_Mxs2TOuCrGdN45vPIZ78NofRlVBws",
+  "ri": "EuqwB_iOD86eK0ynAhA6AYwWvPeBhvmbcmOD-9cCmiVU",
+  "s": "EDpuiVPt4_sa1pShx6vOCnseru1edVPeNvRaQm6HrmMI",
+  "a": {
+    "d": "E9-86Jag34CrJpfNFz_-7E5HA0Dj0FvcYNoFVe7qwkiI",
+    "dt": "2022-08-25T14:07:30.536257+00:00",
+    "i": "EY4ldIBDZP4Tpnm3RX320BO0yz8Uz2nUSN-C409GnCJM",
+    "AID": "Esf8b_AngI1d0KbOFjPGIfpVani0HTagWeaYTLs14PlE",
+    "LEI": "6383001AJTYIGC8Y1X37",
+    "personLegalName": "John Smith",
+    "officialRole": "Chief Executive Officer"
+  },
+  "e": {
+    "d": "EsOf5_YgX_64z4YuHNFWLUnIKcyvsVQOe_vJ_638X6gE",
+    "le": {
+      "n": "ESyLzoJC4L_1abXOEN4f6uNZCmhqyEHg2geBHFhJ8KDs",
+      "s": "EWJkQCFvKuyxZi582yJPb0wcwuW3VXmFNuvbQuBpgmIs"
+    }
+  },
+  "r": {
+    "d": "EDIai3Wkd-Z_4cezz9nYEcCK3KNH5saLvZoS_84JL6NU",
+    "usageDisclaimer": "Usage of a valid Legal Entity vLEI Credential does not assert that the Legal Entity is trustworthy, honest, reputable in its business dealings, safe to do business with, or compliant with any laws.",
+    "issuanceDisclaimer": "Issuance of a valid Legal Entity vLEI Credential only establishes that the information in the requirements in the Identity Verification section 6.3 of the Credential Governance Framework were met in accordance with the vLEI Ecosystem Governance Framework."
+  }
+}

--- a/samples/acdc/verifiable-ixbrl-report-attestation.json
+++ b/samples/acdc/verifiable-ixbrl-report-attestation.json
@@ -74,7 +74,7 @@
     "d": "EmUUy3omMfVOMLKzfPCCpQJ2D867hbWkaYuZXFAmQQhM",
     "oor": {
       "n": "EClJXgZZtvTfXLKf5-0bqOwN7XtA5SgVcfdX5u7uqbBE",
-      "s": "E2RzmSCFmG2a5U2OqZF-yUobeSYkW-a3FsN82eZXMxY0"
+      "s": "EzWz2j8AzVxFr3g1vy6NTERpy5GNZIOyjhkoniMMGUY4"
     }
   }
 }

--- a/schema/acdc/ecr-authorization-vlei-credential.json
+++ b/schema/acdc/ecr-authorization-vlei-credential.json
@@ -1,9 +1,9 @@
 {
-  "$id": "EzWz2j8AzVxFr3g1vy6NTERpy5GNZIOyjhkoniMMGUY4",
+  "$id": "ELG17Q0M-uLZcjidzVbF7KBkoUhZa1ie3Az3Q_8aYi8s",
   "$schema": "http://json-schema.org/draft-07/schema#",
-  "title": "Legal Entity Official Organizational Role vLEI Credential",
-  "description": "A vLEI Role Credential issued by a Qualified vLEI issuer to official representatives of a Legal Entity",
-  "credentialType": "LegalEntityOfficialOrganizationalRolevLEICredential",
+  "title": "ECR Authorization vLEI Credential",
+  "description": "A vLEI Authorization Credential issued by a Legal Entity to a QVI for the authorization of ECR credentials",
+  "credentialType": "ECRAuthorizationvLEICredential",
   "properties": {
     "v": {
       "type": "string"
@@ -36,13 +36,16 @@
           "format": "date-time",
           "type": "string"
         },
+        "AID": {
+          "type": "string"
+        },
         "LEI": {
           "type": "string"
         },
         "personLegalName": {
           "type": "string"
         },
-        "officialRole": {
+        "engagementContextRole": {
           "type": "string"
         }
       },
@@ -50,9 +53,10 @@
       "required": [
         "i",
         "dt",
+        "AID",
         "LEI",
         "personLegalName",
-        "officialRole"
+        "engagementContextRole"
       ],
       "type": "object"
     },
@@ -63,40 +67,7 @@
           "description": "said of edges block",
           "type": "string"
         },
-        "o": {
-          "type": "string",
-          "description": "operator indicating this node is not the issuer",
-          "enum": [
-            "AND",
-            "OR"
-          ]
-        },
-        "auth": {
-          "description": "chain to Auth vLEI credential from legal entity",
-          "properties": {
-            "n": {
-              "type": "string"
-            },
-            "s": {
-              "type": "string",
-              "description": "SAID of required schema of the credential pointed to by this node",
-              "const": "EDpuiVPt4_sa1pShx6vOCnseru1edVPeNvRaQm6HrmMI"
-            },
-            "o": {
-              "type": "string",
-              "description": "operator indicating this node is not the issuer",
-              "const": "NI2I"
-            }
-          },
-          "additionalProperties": false,
-          "required": [
-            "n",
-            "s",
-            "o"
-          ],
-          "type": "object"
-        },
-        "qvi": {
+        "le": {
           "description": "chain to legal entity vLEI credential",
           "properties": {
             "n": {
@@ -105,19 +76,13 @@
             "s": {
               "type": "string",
               "description": "SAID of required schema of the credential pointed to by this node",
-              "const": "EWCeT9zTxaZkaC_3-amV2JtG6oUxNA36sCC0P5MI7Buw"
-            },
-            "o": {
-              "type": "string",
-              "description": "operator indicating this node is not the issuer",
-              "const": "I2I"
+              "const": "EWJkQCFvKuyxZi582yJPb0wcwuW3VXmFNuvbQuBpgmIs"
             }
           },
           "additionalProperties": false,
           "required": [
             "n",
-            "s",
-            "o"
+            "s"
           ],
           "type": "object"
         }
@@ -125,8 +90,7 @@
       "additionalProperties": false,
       "required": [
         "d",
-        "auth",
-        "qvi"
+        "le"
       ],
       "type": "object"
     },

--- a/schema/acdc/legal-entity-engagement-context-role-vLEI-credential.json
+++ b/schema/acdc/legal-entity-engagement-context-role-vLEI-credential.json
@@ -1,5 +1,5 @@
 {
-  "$id": "EKrJtKr528-QBE9VkhKLwpXXGJ4YyVrzYWSkR7KpsNdw",
+  "$id": "EwG_7aZDN7OTBVwETjj7ZMs-xsfH4bX111iKdwE104Yg",
   "$schema": "http://json-schema.org/draft-07/schema#",
   "title": "Legal Entity Engagement Context Role vLEI Credential",
   "description": "A vLEI Role Credential issued to representatives of a Legal Entity in other than official roles but in functional or other context of engagement",
@@ -74,8 +74,8 @@
               "description": "operator",
               "const": "AND"
             },
-            "le": {
-              "description": "chain to legal entity vLEI credential",
+            "auth": {
+              "description": "chain to Auth vLEI credential from legal entity",
               "properties": {
                 "n": {
                   "type": "string"
@@ -83,7 +83,7 @@
                 "s": {
                   "type": "string",
                   "description": "SAID of required schema of the credential pointed to by this node",
-                  "const": "EWJkQCFvKuyxZi582yJPb0wcwuW3VXmFNuvbQuBpgmIs"
+                  "const": "ELG17Q0M-uLZcjidzVbF7KBkoUhZa1ie3Az3Q_8aYi8s"
                 },
                 "o": {
                   "type": "string",
@@ -128,7 +128,7 @@
           "additionalProperties": false,
           "required": [
             "d",
-            "le",
+            "auth",
             "qvi"
           ],
           "type": "object"

--- a/schema/acdc/oor-authorization-vlei-credential.json
+++ b/schema/acdc/oor-authorization-vlei-credential.json
@@ -1,9 +1,9 @@
 {
-  "$id": "EzWz2j8AzVxFr3g1vy6NTERpy5GNZIOyjhkoniMMGUY4",
+  "$id": "EDpuiVPt4_sa1pShx6vOCnseru1edVPeNvRaQm6HrmMI",
   "$schema": "http://json-schema.org/draft-07/schema#",
-  "title": "Legal Entity Official Organizational Role vLEI Credential",
-  "description": "A vLEI Role Credential issued by a Qualified vLEI issuer to official representatives of a Legal Entity",
-  "credentialType": "LegalEntityOfficialOrganizationalRolevLEICredential",
+  "title": "OOR Authorization vLEI Credential",
+  "description": "A vLEI Authorization Credential issued by a Legal Entity to a QVI for the authorization of OOR credentials",
+  "credentialType": "OORAuthorizationvLEICredential",
   "properties": {
     "v": {
       "type": "string"
@@ -36,6 +36,9 @@
           "format": "date-time",
           "type": "string"
         },
+        "AID": {
+          "type": "string"
+        },
         "LEI": {
           "type": "string"
         },
@@ -50,6 +53,7 @@
       "required": [
         "i",
         "dt",
+        "AID",
         "LEI",
         "personLegalName",
         "officialRole"
@@ -63,40 +67,7 @@
           "description": "said of edges block",
           "type": "string"
         },
-        "o": {
-          "type": "string",
-          "description": "operator indicating this node is not the issuer",
-          "enum": [
-            "AND",
-            "OR"
-          ]
-        },
-        "auth": {
-          "description": "chain to Auth vLEI credential from legal entity",
-          "properties": {
-            "n": {
-              "type": "string"
-            },
-            "s": {
-              "type": "string",
-              "description": "SAID of required schema of the credential pointed to by this node",
-              "const": "EDpuiVPt4_sa1pShx6vOCnseru1edVPeNvRaQm6HrmMI"
-            },
-            "o": {
-              "type": "string",
-              "description": "operator indicating this node is not the issuer",
-              "const": "NI2I"
-            }
-          },
-          "additionalProperties": false,
-          "required": [
-            "n",
-            "s",
-            "o"
-          ],
-          "type": "object"
-        },
-        "qvi": {
+        "le": {
           "description": "chain to legal entity vLEI credential",
           "properties": {
             "n": {
@@ -105,19 +76,13 @@
             "s": {
               "type": "string",
               "description": "SAID of required schema of the credential pointed to by this node",
-              "const": "EWCeT9zTxaZkaC_3-amV2JtG6oUxNA36sCC0P5MI7Buw"
-            },
-            "o": {
-              "type": "string",
-              "description": "operator indicating this node is not the issuer",
-              "const": "I2I"
+              "const": "EWJkQCFvKuyxZi582yJPb0wcwuW3VXmFNuvbQuBpgmIs"
             }
           },
           "additionalProperties": false,
           "required": [
             "n",
-            "s",
-            "o"
+            "s"
           ],
           "type": "object"
         }
@@ -125,8 +90,7 @@
       "additionalProperties": false,
       "required": [
         "d",
-        "auth",
-        "qvi"
+        "le"
       ],
       "type": "object"
     },

--- a/schema/acdc/verifiable-ixbrl-report-attestation.json
+++ b/schema/acdc/verifiable-ixbrl-report-attestation.json
@@ -1,5 +1,5 @@
 {
-  "$id": "Ehwr6tZh6XakKBKWQW07otQ9uCwg0g7CF-dPz9qb_fwQ",
+  "$id": "EH9jKc3FQ0O2hvp7YPG5sFBgM7wUFVy4OlssP038w6j0",
   "$schema": "http://json-schema.org/draft-07/schema#",
   "title": "iXBRL Data Value Attestation",
   "description": "A data attestation against an iXBRL report, linked to either a vLEI OOR or vLEI ECR credential",
@@ -116,7 +116,7 @@
                 "s": {
                   "type": "string",
                   "description": "SAID of required schema of the credential pointed to by this node",
-                  "const": "E2RzmSCFmG2a5U2OqZF-yUobeSYkW-a3FsN82eZXMxY0"
+                  "const": "EzWz2j8AzVxFr3g1vy6NTERpy5GNZIOyjhkoniMMGUY4"
                 }
               },
               "additionalProperties": false,
@@ -150,7 +150,7 @@
                 "s": {
                   "type": "string",
                   "description": "SAID of required schema of the credential pointed to by this node",
-                  "const": "ECr_axOPYff2VQl98Dx9n2-mwFSK4zD5ak88S-tJiJP0"
+                  "const": "EwG_7aZDN7OTBVwETjj7ZMs-xsfH4bX111iKdwE104Yg"
                 }
               },
               "additionalProperties": false,

--- a/src/vlei/server.py
+++ b/src/vlei/server.py
@@ -32,7 +32,7 @@ parser.add_argument('-o', '--oobi-dir',
 
 def launch(args):
     app = falcon.App()
-    server = http.Server(port=args.http, app=app)
+    server = http.Server(port=int(args.http), app=app)
     httpServerDoer = http.ServerDoer(server=server)
 
     serving.loadEnds(app, schemaDir=args.schemaDir, credDir=args.credDir, oobiDir=args.oobiDir)

--- a/tests/test_schema.py
+++ b/tests/test_schema.py
@@ -9,7 +9,9 @@ from keri.core import scheming
                                       "legal-entity-engagement-context-role-vLEI-credential.json",
                                       "legal-entity-official-organizational-role-vLEI-credential.json",
                                       "legal-entity-vLEI-credential.json",
-                                      "qualified-vLEI-issuer-vLEI-credential.json"])
+                                      "qualified-vLEI-issuer-vLEI-credential.json",
+                                      "oor-authorization-vlei-credential.json",
+                                      "ecr-authorization-vlei-credential.json"])
 @pytest.mark.parametrize("fmt", ["acdc"])
 def test_schema_example(fmt, filename):
     with open(f'{Path(__file__).parent}/../schema/{fmt}/{filename}', 'r') as schema, \


### PR DESCRIPTION
These new credential types are for the OOR Authorization and ECR Authorization workflows.  These credentials will be issued from a Legal Entity to a QVI to authorize the issuance of an OOR or ECR credential respectively.

Signed-off-by: pfeairheller <pfeairheller@gmail.com>