### PR TITLE
improve startup error message when bind on http port fails

### DIFF
--- a/src/vlei/server.py
+++ b/src/vlei/server.py
@@ -33,6 +33,8 @@ parser.add_argument('-o', '--oobi-dir',
 def launch(args):
     app = falcon.App()
     server = http.Server(port=int(args.http), app=app)
+    if not server.reopen():
+        raise RuntimeError(f"cannot create http server on port {int(args.http)}")
     httpServerDoer = http.ServerDoer(server=server)
 
     serving.loadEnds(app, schemaDir=args.schemaDir, credDir=args.credDir, oobiDir=args.oobiDir)


### PR DESCRIPTION
Fixing issue https://github.com/WebOfTrust/keripy/issues/455 for vLEI-server

New startup error message 

```
$ vLEI-server -s schema/acdc -c samples/acdc -o samples/oobis
Traceback (most recent call last):
  File "/home/uroot/.local/bin/vLEI-server", line 33, in <module>
    sys.exit(load_entry_point('vlei', 'console_scripts', 'vLEI-server')())
  File "/home/uroot/vLEI/src/vlei/server.py", line 51, in main
    launch(args)
  File "/home/uroot/vLEI/src/vlei/server.py", line 37, in launch
    raise RuntimeError(f"cannot create http server on port {int(args.http)}")
RuntimeError: cannot create http server on port 7723
```

Error message before the fix

```
$ vLEI-server -s schema/acdc -c samples/acdc -o samples/oobis
caching schema EBNaNu-M9P5cgrnfl2Fvymy4E_jvxxyjb70PRtiANlJy
caching schema EMhvwOlyEJ9kN4PrwCpr9Jsv7TxPhiYveZ0oP3lJzdEi
caching schema EEy9PkikFcANV1l7EHukCeXqrzT1hNZjGlUk7wuMO5jw
caching schema EH6ekLjSr8V32WyFbGe1zXjTzFs9PkTYmupJ9H65O14g
caching schema EKA57bKBKxr_kN7iN5i7lMUxpMG-s19dRcmov1iDxz-E
caching schema EBfdlu8R27Fbx-ehrqwImnK-8Cm79sqbAQ4MmvEAYqao
caching schema ENPXp1vQzRF6JwIuS-mp2U8Uf1MoADoP_GqQ62VsDZWY
caching credential E4OU1DuxIAtRRscHSSQCO0UIpk3tVc0QHaNBDUmpHKac
caching credential EBzltAGk2r2ztLpT7bqWln_Btb_pVowElbKxvqbG4_n4
caching credential EDNGKQxRTNLcwXMgzaVNLQAzjieGDr_bAk4cYRRazIdc
caching credential ETZG0gFx5uLib9uMQUnP5eQUMrs7XulFeqjCiRtVPdUg
caching credential EGgAMmz2ccR25RQMB-yuK1Jm4INx2ReJbnKSmMDNwiPk
caching credential Eg8ERvoA7nYOxFIN8WC0JGSF0HNoNzVldT2TR92YuAY0
caching credential EOu73a50TLWJiUOHdyMV8La6-5_VU7rb2QmUr3kMaMs8
Traceback (most recent call last):
  File "/home/uroot/.local/bin/vLEI-server", line 33, in <module>
    sys.exit(load_entry_point('vlei', 'console_scripts', 'vLEI-server')())
  File "/home/uroot/vLEI/src/vlei/server.py", line 49, in main
    launch(args)
  File "/home/uroot/vLEI/src/vlei/server.py", line 44, in launch
    doist.do(doers=doers)
  File "/home/uroot/.local/lib/python3.10/site-packages/hio/base/doing.py", line 156, in do
    self.recur()  # increments .tyme runs recur context
  File "/home/uroot/.local/lib/python3.10/site-packages/hio/base/doing.py", line 275, in recur
    tock = dog.send(self.tyme)  # yielded tock == 0.0 means re-run asap
  File "/home/uroot/.local/lib/python3.10/site-packages/hio/base/doing.py", line 568, in do
    self.done = self.recur(tyme=tyme)
  File "/home/uroot/.local/lib/python3.10/site-packages/hio/core/http/serving.py", line 1359, in recur
    self.server.service()
  File "/home/uroot/.local/lib/python3.10/site-packages/hio/core/http/serving.py", line 846, in service
    self.serviceConnects()
  File "/home/uroot/.local/lib/python3.10/site-packages/hio/core/http/serving.py", line 765, in serviceConnects
    self.servant.serviceConnects()
  File "/home/uroot/.local/lib/python3.10/site-packages/hio/core/tcp/serving.py", line 292, in serviceConnects
    self.serviceAxes()
  File "/home/uroot/.local/lib/python3.10/site-packages/hio/core/tcp/serving.py", line 269, in serviceAxes
    self.serviceAccepts()  # populate .axes
  File "/home/uroot/.local/lib/python3.10/site-packages/hio/core/tcp/serving.py", line 196, in serviceAccepts
    cs, ca = self.accept()
  File "/home/uroot/.local/lib/python3.10/site-packages/hio/core/tcp/serving.py", line 182, in accept
    cs, ca = self.ss.accept()  # virtual connection (socket, host address)
AttributeError: 'NoneType' object has no attribute 'accept'
```
