### PR TITLE
Enable TLS

### DIFF
--- a/src/vlei/server.py
+++ b/src/vlei/server.py
@@ -7,7 +7,7 @@ import argparse
 
 import falcon
 from hio.base import doing
-from hio.core import http
+from hio.core import http, tcp
 
 from vlei.app import serving
 
@@ -28,11 +28,52 @@ parser.add_argument('-o', '--oobi-dir',
                     action='store', dest="oobiDir",
                     required=True,
                     help="Directory of OOBIs to serve")
+parser.add_argument("--keypath", action="store", required=False, default=None,
+                    help="TLS server private key file")
+parser.add_argument("--certpath", action="store", required=False, default=None,
+                    help="TLS server signed certificate (public key) file")
+parser.add_argument("--cafilepath", action="store", required=False, default=None,
+                    help="TLS server CA certificate chain")
+
+
+def createHttpServer(port, app, keypath=None, certpath=None, cafilepath=None):
+    """
+    Create an HTTP or HTTPS server depending on whether TLS key material is present
+
+    Parameters:
+        port (int)         : port to listen on for all HTTP(s) server instances
+        app (falcon.App)   : application instance to pass to the http.Server instance
+        keypath (string)   : the file path to the TLS private key
+        certpath (string)  : the file path to the TLS signed certificate (public key)
+        cafilepath (string): the file path to the TLS CA certificate chain file
+    Returns:
+        hio.core.http.Server
+    """
+    if keypath is not None and certpath is not None and cafilepath is not None:
+        servant = tcp.ServerTls(certify=False,
+                                keypath=keypath,
+                                certpath=certpath,
+                                cafilepath=cafilepath,
+                                port=port)
+        server = http.Server(port=port, app=app, servant=servant)
+    else:
+        server = http.Server(port=port, app=app)
+    return server
 
 
 def launch(args):
     app = falcon.App()
-    server = http.Server(port=int(args.http), app=app)
+    port = int(args.http)
+    keypath = args.keypath
+    certpath = args.certpath
+    cafilepath = args.cafilepath
+    if keypath is not None and certpath is not None and cafilepath is not None:
+        print(f"Starting on port {port} with TLS enabled")
+    else:
+        print(f"Starting on port {port} with TLS disabled")
+    server = createHttpServer(port=int(args.http), app=app,
+                              keypath=args.keypath, certpath=args.certpath,
+                              cafilepath=args.cafilepath)
     if not server.reopen():
         raise RuntimeError(f"cannot create http server on port {int(args.http)}")
     httpServerDoer = http.ServerDoer(server=server)


### PR DESCRIPTION
Adds the same function KERIA and KERIpy have to enable TLS for the vLEI Server.

An example command to run the vLEI-server with TLS is as follows:
```bash
vLEI-server \
    -s ./schema/acdc \
    -c ./samples/acdc/ \
    -o ./samples/oobis/ \
    --keypath ecc.private.key \
    --certpath signed-certificate.crt \
    --cafilepath ca-cert-bundle.ca-bundle
```